### PR TITLE
feat: Add Cruise Control plugin

### DIFF
--- a/sos/report/plugins/charmed_cruise_control.py
+++ b/sos/report/plugins/charmed_cruise_control.py
@@ -1,0 +1,138 @@
+from datetime import datetime, timedelta
+import json
+from sos.report.plugins import Plugin, UbuntuPlugin, PluginOpt
+import glob
+import re
+
+PATHS = {
+    "CONF": f"/var/snap/charmed-kafka/current/etc/cruise-control",
+    "LOGS": f"/var/snap/charmed-kafka/common/var/log/cruise-control",
+}
+
+DATE_FORMAT = "%Y-%m-%d-%H"
+
+
+class CharmedCruiseControl(Plugin, UbuntuPlugin):
+
+    short_desc = "Cruise Control (from Charmed Kafka)"
+    plugin_name = "charmed_cruise_control"
+
+    current_date = datetime.now()
+    default_date_from = "1970-01-01-00"
+    default_date_to = (current_date + timedelta(hours=1)).strftime(DATE_FORMAT)
+
+    option_list = [
+        PluginOpt(
+            "date-from",
+            default="1970-01-01-00",
+            desc="date from which to filter logs, in format YYYY-MM-DD-HH",
+            val_type=str,
+        ),
+        PluginOpt(
+            "date-to",
+            default=default_date_to,
+            desc="date to which to filter logs, in format YYYY-MM-DD-HH",
+            val_type=str,
+        ),
+    ]
+
+    @property
+    def credentials_args(self) -> str:
+        with open(f"{PATHS['CONF']}/cruisecontrol.credentials") as f:
+            content = f.read().strip()
+
+        if match := re.match(r"balancer: (?P<pwd>\w+),ADMIN", content):
+            pwd = match.group("pwd")
+            return f"-u balancer:{pwd}"
+        else:
+            return ""
+
+    def setup(self):
+        # --- FILE EXCLUSIONS ---
+
+        for file in glob.glob(f"{PATHS['LOGS']}/*"):
+            date = re.search(
+                pattern=r"([0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2})", string=file
+            )
+
+            # include files without date, aka current files
+            if not date:
+                continue
+
+            file_dt = datetime.strptime(date.group(1), DATE_FORMAT)
+
+            if file_dt < datetime.strptime(
+                str(self.get_option("date-from")), DATE_FORMAT
+            ) or file_dt > datetime.strptime(
+                str(self.get_option("date-to")), DATE_FORMAT
+            ):
+                # skip files outside given range
+                self.add_forbidden_path(file)
+
+        # hide keys/stores
+        self.add_forbidden_path(
+            [
+                f"{PATHS['CONF']}/*.pem",
+                f"{PATHS['CONF']}/*.key",
+                f"{PATHS['CONF']}/*.p12",
+                f"{PATHS['CONF']}/*.jks",
+            ]
+        )
+
+        # --- FILE INCLUSIONS ---
+
+        self.add_copy_spec(
+            [
+                f"{PATHS['CONF']}",
+                f"{PATHS['LOGS']}",
+                "/var/log/juju",
+            ]
+        )
+
+        # --- SNAP LOGS ---
+
+        self.add_cmd_output(
+            "snap logs charmed-kafka.cruise-control -n 100000",
+            suggest_filename="snap-logs",
+        )
+
+        # --- CRUISE CONTROL STATE ---
+
+        self.add_cmd_output(
+            f"curl {self.credentials_args} localhost:9090/kafkacruisecontrol/state?super_verbose=true",
+            "cruise-control-state",
+        )
+
+        # --- CLUSTER STATE ---
+
+        self.add_cmd_output(
+            f"curl {self.credentials_args} localhost:9090/kafkacruisecontrol/kafka_cluster_state?verbose=true",
+            "cluster-state",
+        )
+
+        # --- PARTITION LOAD ---
+
+        self.add_cmd_output(
+            f"curl {self.credentials_args} localhost:9090/kafkacruisecontrol/partition_load",
+            "partition-load",
+        )
+
+        # --- USER TASKS ---
+
+        self.add_cmd_output(
+            f"curl {self.credentials_args} localhost:9090/kafkacruisecontrol/user_tasks",
+            "user-tasks",
+        )
+
+        # --- JMX METRICS ---
+
+        self.add_cmd_output("curl localhost:9102/metrics", "jmx-metrics")
+
+    def postproc(self):
+        # --- SCRUB PASSWORDS ---
+
+        self.do_path_regex_sub(
+            f"{PATHS['CONF']}/*",
+            r'(password=")[^"]*',
+            r"\1*********",
+        )

--- a/sos/report/plugins/charmed_cruise_control.py
+++ b/sos/report/plugins/charmed_cruise_control.py
@@ -136,3 +136,9 @@ class CharmedCruiseControl(Plugin, UbuntuPlugin):
             r'(password=")[^"]*',
             r"\1*********",
         )
+
+        self.do_path_regex_sub(
+            f"{PATHS['CONF']}/*",
+            r"(balancer: )[^,]*",
+            r"\1*********",
+        )

--- a/sos/report/plugins/charmed_cruise_control.py
+++ b/sos/report/plugins/charmed_cruise_control.py
@@ -131,14 +131,9 @@ class CharmedCruiseControl(Plugin, UbuntuPlugin):
     def postproc(self):
         # --- SCRUB PASSWORDS ---
 
-        self.do_path_regex_sub(
-            f"{PATHS['CONF']}/*",
-            r'(password=")[^"]*',
-            r"\1*********",
-        )
-
-        self.do_path_regex_sub(
-            f"{PATHS['CONF']}/*",
-            r"(balancer: )[^,]*",
-            r"\1*********",
-        )
+        for scrub_pattern in [r'(password=")[^"]*', r"(balancer: )[^,]*"]:
+            self.do_path_regex_sub(
+                f"{PATHS['CONF']}/*",
+                scrub_pattern,
+                r"\1*********",
+            )


### PR DESCRIPTION
This PR adds a Cruise Control (provided by Charmed Kafka) plugin.

All in all, a very fun ticket!


How to test, in a lxd model

```
juju add-model temp
juju deploy zookeeper --channel edge -n 3
juju deploy kafka --channel edge -n 3 --config roles=broker,balancer
juju relate kafka zookeeper
juju deploy kafka-test-app --series=jammy --channel=edge --config role=producer --config topic_name="HOT-TOPIC" --config num_messages=100000 --force producer
juju relate kafka producer

# wait for active/idle

juju ssh kafka/0 sudo -i

# in SSH session

git clone -b feat/dpe-4953-cruise-control https://github.com/marcoppenheimer/sos.git
cd sos
python3 setup.py install
./bin/sos report --only-plugins "charmed_cruise_control"
cd /tmp
tar xvf *.xz

# inspect the actual outputted files as you wish

fzf --preview='cat {}'

```